### PR TITLE
All the numbers in dungeons are now formatted with commas.

### DIFF
--- a/lib/screens/dungeon/dungeon_info_subtab.dart
+++ b/lib/screens/dungeon/dungeon_info_subtab.dart
@@ -205,7 +205,7 @@ class ExpCoinTable extends StatelessWidget {
   final SubDungeon sd;
   const ExpCoinTable(this.sd, {Key key}) : super(key: key);
 
-  final _format = NumberFormat("###,###,###,###");
+  final _format = NumberFormat.decimalPattern();
 
   @override
   Widget build(BuildContext context) {
@@ -274,7 +274,7 @@ class DungeonBattle extends StatelessWidget {
 class DungeonEncounter extends StatelessWidget {
   final FullEncounter _model;
 
-  final _format = NumberFormat("###,###,###,###");
+  final _format = NumberFormat.decimalPattern();
 
   const DungeonEncounter(this._model, {Key key}) : super(key: key);
 

--- a/lib/screens/dungeon/dungeon_info_subtab.dart
+++ b/lib/screens/dungeon/dungeon_info_subtab.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_fimber/flutter_fimber.dart';
 import 'package:flutter_icons/flutter_icons.dart';
 import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
 
 class DungeonDetailScreen extends StatefulWidget {
   final DungeonDetailArgs args;
@@ -204,6 +205,8 @@ class ExpCoinTable extends StatelessWidget {
   final SubDungeon sd;
   const ExpCoinTable(this.sd, {Key key}) : super(key: key);
 
+  final _format = NumberFormat("###,###,###,###");
+
   @override
   Widget build(BuildContext context) {
     if (sd.expMin == null) return Container(width: 0.0, height: 0.0);
@@ -237,7 +240,7 @@ class ExpCoinTable extends StatelessWidget {
 
   Widget cell(String text) => TableCell(child: Text(text, textAlign: TextAlign.end));
   Widget intCell(int value) =>
-      TableCell(child: Text(value?.toString() ?? '', textAlign: TextAlign.end));
+      TableCell(child: Text(value != null ? _format.format(value) : '', textAlign: TextAlign.end));
 }
 
 class DungeonBattle extends StatelessWidget {
@@ -270,6 +273,8 @@ class DungeonBattle extends StatelessWidget {
 
 class DungeonEncounter extends StatelessWidget {
   final FullEncounter _model;
+
+  final _format = NumberFormat("###,###,###,###");
 
   const DungeonEncounter(this._model, {Key key}) : super(key: key);
 
@@ -325,7 +330,7 @@ class DungeonEncounter extends StatelessWidget {
 
   Widget item(int flex, IconData iconData, int value) {
 //    return Flexible(flex: flex, child: Row(children: [Icon(iconData), Text(value.toString())]));
-    return Expanded(flex: flex, child: Row(children: [Icon(iconData), Text(value.toString())]));
+    return Expanded(flex: flex, child: Row(children: [Icon(iconData), Text(_format.format(value))]));
 //    return Row(children: [Icon(iconData), Text(value.toString())]);
   }
 }

--- a/lib/screens/monster/monster_info_subtab.dart
+++ b/lib/screens/monster/monster_info_subtab.dart
@@ -10,6 +10,7 @@ import 'package:dadguide2/data/data_objects.dart';
 import 'package:dadguide2/data/tables.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
 
 class MonsterDetailScreen extends StatefulWidget {
   final MonsterDetailArgs _args;
@@ -572,7 +573,7 @@ TableCell emptyCell() {
 }
 
 TableCell numCell(num value) {
-  return cell(value.toInt().toString());
+  return cell(NumberFormat.decimalPattern().format(value.toInt()));
 }
 
 TableCell widgetCell(Widget widget) {


### PR DESCRIPTION
PAD suffers from a distinct lack of commas making numbers hard to read. This commit fixes this for numbers in dungeons. This has currently only been tested on the IOS simulator. Also note that I only added in support for numbers less than 1,000,000,000,000, which should cover PAD for the time being. Additionally, I made no effort to support number formats other than that in common use in the United States.