### PR TITLE
Implemented MonsterSkillupDropLocations

### DIFF
--- a/lib/data/data_objects.dart
+++ b/lib/data/data_objects.dart
@@ -147,6 +147,7 @@ class FullMonster {
   final int prevMonsterId;
   final int nextMonsterId;
   final List<int> skillUpMonsters;
+  final Map<int, List<BasicDungeon>> skillUpDungeons;
   final List<FullEvolution> evolutions;
   final Map<int, List<BasicDungeon>> dropLocations;
   final List<int> materialForMonsters;
@@ -162,6 +163,7 @@ class FullMonster {
       this.prevMonsterId,
       this.nextMonsterId,
       this.skillUpMonsters,
+      this.skillUpDungeons,
       this.evolutions,
       this.dropLocations,
       this.materialForMonsters)

--- a/lib/data/tables.dart
+++ b/lib/data/tables.dart
@@ -975,6 +975,12 @@ class MonstersDao extends DatabaseAccessor<DadGuideDatabase> with _$MonstersDaoM
         ? []
         : (await skillUpMonsterIds(resultMonster.activeSkillId)).map((x) => x.monsterId).toList();
 
+    var skillUpDungeons = Map<int, List<BasicDungeon>>();
+    for (var monsterId in skillUpMonsterIdsResult){
+      var skillUpMonsterDropLocations = await findDropDungeons(monsterId);
+      skillUpDungeons[monsterId] = skillUpMonsterDropLocations;
+    }
+
     final evolutionList = await allEvolutionsForTree(resultMonster.monsterId);
 
     var evoTreeIds = {monsterId};
@@ -1000,6 +1006,7 @@ class MonstersDao extends DatabaseAccessor<DadGuideDatabase> with _$MonstersDaoM
       prevMonsterResult.length > 0 ? prevMonsterResult.first.monsterId : null,
       nextMonsterResult.length > 0 ? nextMonsterResult.first.monsterId : null,
       skillUpMonsterIdsResult,
+      skillUpDungeons,
       evolutionList,
       dropLocations,
       materialForMonsters,

--- a/lib/l10n/localizations.dart
+++ b/lib/l10n/localizations.dart
@@ -444,6 +444,9 @@ class DadGuideLocalizations {
   String get monsterInfoSkillupDungeonsTitle => Intl.message('Skill Up - Dungeon',
       name: 'monsterInfoSkillupDungeonsTitle', desc: 'Header for skillup drop dungeons');
 
+  String get monsterInfoSkillupDungeonTitleNone => Intl.message('Skill Up - Dungeon: None',
+      name: 'monsterInfoSkillupDungeonTitleNone', desc: 'Header for skill up dungeon section when there are no drops');
+
   String get monsterInfoTableInfoMaxLevel => Intl.message('At max level',
       name: 'monsterInfoTableInfoMaxLevel', desc: 'Header column with buy/sell/feed data');
 

--- a/lib/screens/monster_info/monster_info_subtab.dart
+++ b/lib/screens/monster_info/monster_info_subtab.dart
@@ -163,10 +163,10 @@ class MonsterDetailContents extends StatelessWidget {
                 ),
 
               if (hasSkillups)
-                Padding(child: MonsterSkillupDropLocations(), padding: EdgeInsets.only(top: 4)),
+                Padding(child: MonsterSkillupDropLocations(_data), padding: EdgeInsets.only(top: 4)),
 
               SizedBox(height: 8),
-              MonsterDropLocations(_data),
+              MonsterDropLocations(_data.dropLocations, loc.monsterInfoDropsTitle),
 
               if (_data.awakenings.isNotEmpty)
                 Padding(
@@ -953,30 +953,33 @@ class MonsterSkillups extends StatelessWidget {
 
 /// Displays dungeons that the monster drops in.
 class MonsterDropLocations extends StatelessWidget {
-  final FullMonster _data;
-  const MonsterDropLocations(this._data, {Key key}) : super(key: key);
+  final Map<int, List<BasicDungeon>> _dropLocations;
+  final String _title;
+  const MonsterDropLocations(this._dropLocations, this._title, {Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     var loc = DadGuideLocalizations.of(context);
 
-    if (_data.dropLocations.isEmpty) {
-      return Text(loc.monsterInfoDropsTitleNone, style: subtitle(context));
+    if (_dropLocations.isEmpty) {
+      return Text(_title == loc.monsterInfoSkillupDungeonsTitle
+          ? loc.monsterInfoSkillupDungeonTitleNone
+          : loc.monsterInfoDropsTitleNone, style: subtitle(context));
     }
 
-    var keys = _data.dropLocations.keys.toList()..sort();
+    var keys = _dropLocations.keys.toList()..sort();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(loc.monsterInfoDropsTitle),
+        Text(_title),
         for (var k in keys)
           Padding(
               padding: EdgeInsets.symmetric(vertical: 4),
               child: Row(
                 children: [
                   PadIcon(k),
-                  Flexible(child: DropDungeonList(dungeons: _data.dropLocations[k])),
+                  Flexible(child: DropDungeonList(dungeons: _dropLocations[k])),
                 ],
               ))
       ],
@@ -1022,18 +1025,19 @@ class DungeonButton extends FlatButton {
 
 /// Locations where the skillup monsters drop.
 class MonsterSkillupDropLocations extends StatelessWidget {
-  const MonsterSkillupDropLocations({Key key}) : super(key: key);
+  final FullMonster _fullMonster;
+  const MonsterSkillupDropLocations(this._fullMonster, {Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     var loc = DadGuideLocalizations.of(context);
+    // Remove duplicate information already displayed in the monster drop section
+    _fullMonster.skillUpDungeons.removeWhere((key, dungeon) => _fullMonster.dropLocations.keys.contains(key) || dungeon.isEmpty);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(loc.monsterInfoSkillupDungeonsTitle),
-        // TODO: if monster appears in a skill-up dungeon should note that too
-        Text('Not implemented yet =(', style: secondary(context)),
+        MonsterDropLocations(_fullMonster.skillUpDungeons, loc.monsterInfoSkillupDungeonsTitle)
       ],
     );
   }


### PR DESCRIPTION
Fixes #41 

To keep the code DRY, I slightly modified the `MonsterDropLocation` stateless widget to be reusable.

Instead of the `FullMonster` object, it receives a `_title` (which should correspond to the localized title) and the `dropLocations`.